### PR TITLE
Implement options method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Provides options method to reuse args for property definition except property name
+
 ## 0.3.0
 
 - Fix keyword arguments error for Ruby 3 support.

--- a/lib/json_world/property_definition.rb
+++ b/lib/json_world/property_definition.rb
@@ -2,6 +2,9 @@ require "active_support/core_ext/object/try"
 
 module JsonWorld
   class PropertyDefinition
+    # @return [Hash{Symbol => Object}]
+    attr_reader :options
+
     # @return [Symbol]
     attr_reader :property_name
 


### PR DESCRIPTION
## What
- Implement `options` method in JsonWorld::PropertyDefinition

## Why
When update this gem to v0.3.0, the following code changes its behavior.

```ruby
class Base
  include JsonWorld::DSL

  class << self
    # @param [Symbol] proprety_name
    def find_property_definition_by_name(property_name)
      property_definitions.find do |property_definition|
        property_definition.property_name == property_name
      end
    end
  end
end
```

```ruby
class Article < Base
  property(
    :user_id,
    User.find_property_definition_by_name(:id).raw_options,
  )
end
```

```ruby
class User < Base
  property(
    :id,
    description: "User's id",
    example: 'yamada_taro',
    type: String,
  )
end
```

### v0.2.6

```ruby
>Article.property_names
=> [:user_id]
```

### v0.3.0

```ruby
>Article.property_names
=> [:id]
```

I want `options` method to prevent override propery name.

```diff
class Article
  include JsonWorld::DSL
  property(
    :user_id,
-    User.find_property_definition_by_name(:id).raw_options,
+    User.find_property_definition_by_name(:id).options,
  )
end
```

```ruby
>Article.property_names
=> [user_id]
```

